### PR TITLE
fix:特定ブランチのみ実施を削除(#6)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,4 @@
 version: 2
-general:
-  branches:
-    only:
-      - develop
 
 jobs:
   build:


### PR DESCRIPTION
close #6 
概要：circleciにて特定ブランチのみで実施していたが、全てのブランチに適用
修正内容の検証方法：当該ブランチへPush後にciが実行されるか
この修正が正しい理由：ciが起動し、正常終了した